### PR TITLE
FIX: Avoid getting stuck in corner near Hive 1 & Ramp, plus various 'return to hive' adjustments

### DIFF
--- a/paths/wf-bamboo.ahk
+++ b/paths/wf-bamboo.ahk
@@ -5,18 +5,20 @@
 send {" RotRight " 2}
 " nm_Walk(75, RightKey) "
 " nm_Walk(64, FwdKey) "
-" nm_Walk(7, FwdKey, RightKey) "
+" nm_Walk(5.5, FwdKey, RightKey) "
 " nm_Walk(36, FwdKey) "
-" nm_Walk(3, BackKey) "
 
 switch % " HiveSlot "
-{
-case 3:
-" nm_Walk(0.25, BackKey) " ; 4.2, BackKey
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
 
-default:
-" nm_Walk(23, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2
-}
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
 ;path 230212 zaappiix
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-blueflower.ahk
+++ b/paths/wf-blueflower.ahk
@@ -5,10 +5,19 @@ send {" RotRight " 2}
 " nm_Walk(4.5, BackKey) "
 " nm_Walk(40.5, RightKey) "
 " nm_Walk(40.5, FwdKey) "
-" nm_Walk(36, RightKey) "
+" nm_Walk(33.5, RightKey) "
 " nm_Walk(27, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(27, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2.25
-)"
 
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
+)"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-cactus.ahk
+++ b/paths/wf-cactus.ahk
@@ -9,9 +9,19 @@
 " nm_Walk(4, FwdKey) "
 " nm_Walk(4, LeftKey) "
 " nm_Walk(27, FwdKey) "
-" nm_Walk(2.25, FwdKey, LeftKey) "
+" nm_Walk(2.75, FwdKey, LeftKey) "
 " nm_Walk(90, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(23.5, RightKey) " ; 22.5
-" nm_Walk(3.5, FwdKey) "  ; 2.25
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-clover.ahk
+++ b/paths/wf-clover.ahk
@@ -3,9 +3,19 @@
 " nm_Walk(18, FwdKey) "
 " nm_Walk(36, RightKey) "
 " nm_Walk(4.5, BackKey) "
-" nm_Walk(49.5, RightKey) "
+" nm_Walk(50.5, RightKey) "
 " nm_Walk(36, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(27, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2.25
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-coconut.ahk
+++ b/paths/wf-coconut.ahk
@@ -10,7 +10,8 @@ Walk(31.5)
 send {" BackKey " up}
 " nm_Walk(33.75, LeftKey) "
 " nm_Walk(13.5, FwdKey) "
-" nm_Walk(3.0, BackKey) "
-" nm_Walk(18, RightKey) "
-" nm_Walk(3.5, FwdKey) "
+" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+" nm_Walk(10, RightKey) " ;walk to ramp
+" nm_Walk(2.7, BackKey) " ;center with hive pads
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update

--- a/paths/wf-dandelion.ahk
+++ b/paths/wf-dandelion.ahk
@@ -2,9 +2,19 @@
 (LTrim Join`r`n
 send {" RotRight " 2}
 " nm_Walk(13.5, FwdKey) "
-" nm_Walk(36, RightKey) "
+" nm_Walk(32, RightKey) "
 " nm_Walk(27, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(27, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2.25
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-mountaintop.ahk
+++ b/paths/wf-mountaintop.ahk
@@ -7,6 +7,19 @@ Loop, 15
 }
 " nm_Walk(36, FwdKey, RightKey) "
 " nm_Walk(100, FwdKey) "
-" nm_Walk(30, RightKey) "
-" nm_Walk(37, FwdKey, RightKey) "
+" nm_Walk(32, RightKey) "
+" nm_Walk(37, FwdKey) "
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-mushroom.ahk
+++ b/paths/wf-mushroom.ahk
@@ -1,10 +1,21 @@
 ﻿paths["mushroom"] := "
 (LTrim Join`r`n
-" nm_Walk(13.5, FwdKey) "
-" nm_Walk(27, RightKey) "
+" nm_Walk(13.5, FwdKey) "   ;move to rear of mushroom field
+" nm_Walk(27, LeftKey) "    ;walk to corner near fence
 send {" RotLeft " 4}
-" nm_Walk(72, FwdKey) "
-" nm_Walk(3, BackKey) "
-" nm_Walk(49.5, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2.25
+" nm_Walk(11.5, LeftKey) "  ;align with SpawnLocation
+" nm_Walk(72, FwdKey) "     ;walk towards hives
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-pepper.ahk
+++ b/paths/wf-pepper.ahk
@@ -1,12 +1,15 @@
 ﻿paths["pepper"] := "
 (LTrim Join`r`n
 " nm_Walk(42, RightKey) "
-" nm_Walk(45, BackKey) "
-" nm_Walk(50, RightKey) "
-" nm_Walk(54, BackKey) "
-send {" RotLeft " 2}
+send {" RotLeft " 4}
+" nm_Walk(45, FwdKey) "
+" nm_Walk(50, LeftKey) "
+" nm_Walk(49, FwdKey) "
+send {" RotRight " 2}
 " nm_Walk(13.5, FwdKey) "
-" nm_Walk(3, BackKey) "
-" nm_Walk(18, RightKey) "
-" nm_Walk(3.75, FwdKey) "
+" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+" nm_Walk(10, RightKey) " ;walk to ramp
+" nm_Walk(2.7, BackKey) " ;center with hive pads
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Updated camera angle to 'follow' user to hive, less disorienting

--- a/paths/wf-pineapple.ahk
+++ b/paths/wf-pineapple.ahk
@@ -25,11 +25,19 @@ if (" HiveBees " < 12) {
 	" nm_Walk(4.5, BackKey) "
 	" nm_Walk(40.5, RightKey) "
 	" nm_Walk(40.5, FwdKey) "
-	" nm_Walk(36, RightKey) "
+	" nm_Walk(34.5, RightKey) "
 	" nm_Walk(27, FwdKey) "
-	" nm_Walk(3, BackKey) " ; 2.25
-	" nm_Walk(27, RightKey) "
-	" nm_Walk(3.5, FwdKey) " ; 2.25
+
+	switch % " HiveSlot "
+		{
+		case 3:
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+		default:
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
+		}
 	}
 else {
     send {space down}
@@ -41,8 +49,21 @@ else {
     HyperSleep(100)
     send {e up}
     Hypersleep(3000)
-    " nm_Walk(34, FwdKey, RightKey) "
+    " nm_Walk(34, FwdKey) "
+
+	switch % " HiveSlot "
+		{
+		case 3:
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+		default:
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
+		}
     }
 )"
 
 ; added walk path if <12 bees, misc 17/11/23
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-pinetree.ahk
+++ b/paths/wf-pinetree.ahk
@@ -14,15 +14,16 @@
 	send {" SC_Space " up}
 	Walk(108)
 	send {" FwdKey " up}
-	" nm_Walk(3, BackKey) "
+
 	switch % " HiveSlot "
 		{
 		case 3:
-		" nm_Walk(0.25, BackKey) " ; 4.2, BackKey
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
 
 		default:
-		" nm_Walk(23, RightKey) "
-		" nm_Walk(3.5, FwdKey) " ; 2
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
 		}
 	)"
 	}
@@ -48,15 +49,16 @@ else {
 	send {" FwdKey " up}
 	HyperSleep(2600)
 	" nm_Walk(13, FwdKey) "
-	" nm_Walk(3, BackKey) "
+
 	switch % " HiveSlot "
 		{
 		case 3:
-		" nm_Walk(0.25, BackKey) " ; 4.2, BackKey
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
 
 		default:
-		" nm_Walk(23, RightKey) "
-		" nm_Walk(3.5, FwdKey) " ; 2
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
 		}
 	)"
 	}
@@ -64,3 +66,5 @@ else {
 ;added MoveMethod condition to no-glider option misc 181123
 ;slightly altered tile measurements and optimised glider deployment SP 230405
 ;path with and without glider zaappiix 230212
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-pumpkin.ahk
+++ b/paths/wf-pumpkin.ahk
@@ -16,9 +16,19 @@ send {" LeftKey " up}
 " nm_Walk(4.5, FwdKey, RightKey) "
 " nm_Walk(4.5, FwdKey, LeftKey) "
 " nm_Walk(27, FwdKey) "
-" nm_Walk(2.25, FwdKey, LeftKey) "
+" nm_Walk(3, FwdKey, LeftKey) "
 " nm_Walk(85.5, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(22.5, RightKey) "
-" nm_Walk(3.5, FwdKey) " ; 2.25
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-rose.ahk
+++ b/paths/wf-rose.ahk
@@ -11,8 +11,9 @@ send {" RotLeft " 2}
 " nm_Walk(8, LeftKey) "
 " nm_Walk(6, FwdKey, LeftKey) "
 " nm_Walk(6, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(10, RightKey) "
-" nm_Walk(3.5, FwdKey) "
+" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+" nm_Walk(35, RightKey) " ;walk to ramp
+" nm_Walk(2.7, BackKey) " ;center with hive pads
 )"
 ;path 230212 zaappiix
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update

--- a/paths/wf-spider.ahk
+++ b/paths/wf-spider.ahk
@@ -3,9 +3,21 @@
 " nm_Walk(22.5, FwdKey) "
 " nm_Walk(27, LeftKey) "
 send {" RotLeft " 4}
-" nm_Walk(40.5, FwdKey) "
-" nm_Walk(4.375, FwdKey, RightKey) " ; 3.375
-" nm_Walk(38, FwdKey) "
-" nm_Walk(30, RightKey, FwdKey) "
-" nm_Walk(4, RightKey) "
+" nm_Walk(64, FwdKey) "
+" nm_Walk(5.5, FwdKey, RightKey) "
+" nm_Walk(36, FwdKey) "
+
+switch % " HiveSlot "
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
+
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-strawberry.ahk
+++ b/paths/wf-strawberry.ahk
@@ -1,28 +1,25 @@
 ﻿paths["strawberry"] := "
 (LTrim Join`r`n
 Send {"RotLeft " 2}
-" nm_Walk(12, BackKey) "
-" nm_Walk(15, BackKey, LeftKey) "
-" nm_Walk(18, LeftKey) "
-" nm_Walk(10, FwdKey) "
-" nm_Walk(2, FwdKey, RightKey) "
-" nm_Walk(59, FwdKey) "
-" nm_Walk(8, LeftKey) "
-" nm_Walk(2, FwdKey) "
-" nm_Walk(5, RightKey) "
-" nm_Walk(3, LeftKey) "
-" nm_Walk(46, FwdKey) "
-" nm_Walk(3, BackKey) "
+" nm_Walk(12, BackKey) "            ;walk back against wall
+" nm_Walk(15, BackKey, LeftKey) "   ;move to corner (betwen strawberry & vicious bee)
+" nm_Walk(18, LeftKey) "            ;ensure against vicious bee platform
+" nm_Walk(15, FwdKey) "             ;move forward past vicious bee platform
+" nm_Walk(6, LeftKey) "             ;align with SpawnLocation
+" nm_Walk(95, FwdKey) "             ;walk towards hives
 
 switch % " HiveSlot "
-{
-case 3:
-" nm_Walk(0.25, BackKey) " ; 4.2, BackKey
-HyperSleep(50)
+    {
+    case 3:
+    " nm_Walk(2.7, BackKey) " ;center on hive pad 3
 
-default:
-" nm_Walk(23, RightKey) "
-" nm_Walk(3.5, FwdKey) "
-}
+    default:
+    " nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+    " nm_Walk(35, RightKey) " ;walk to ramp
+    " nm_Walk(2.7, BackKey) " ;center with hive pads
+    }
 )"
 ;zaappiix 230203
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] No longer uses the Instant Converter corner to align
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-stump.ahk
+++ b/paths/wf-stump.ahk
@@ -63,5 +63,5 @@ else { ;use yellow cannon
     }
 )"
 ; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
-; [2024-01-15/rpertusio] Now uses yellow cannon if 12+ bees
+; [2024-01-15/rpertusio] Now can walk without yellow cannon if < 12 bees
 ; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-stump.ahk
+++ b/paths/wf-stump.ahk
@@ -8,12 +8,60 @@ send {" RotRight " 2}
 " nm_Walk(40.5, FwdKey) "
 " nm_Walk(5.5, BackKey) "
 " nm_Walk(10, RightKey) "
-send {space down}
-Hypersleep(50)
-send {space up}
-" nm_walk(4, rightkey) "
-Hypersleep(1000)
-send {e}
-Hypersleep(3000)
-" nm_Walk(34, FwdKey, RightKey) "
+if (" HiveBees " < 12) { ;walk
+	" nm_Walk(12, FwdKey) "
+	" nm_Walk(8, RightKey) "
+	send {" RotRight " 2}
+	send {" FwdKey " down}
+	send {space down}
+	Hypersleep(200)
+	send {space up}
+	send {" FwdKey " up}
+	" nm_walk(30, FwdKey) "
+	" nm_walk(3, BackKey) "
+	send {" RotLeft " 2}
+	" nm_walk(30, FwdKey) "
+	" nm_Walk(4.5, BackKey) "
+	" nm_Walk(40.5, RightKey) "
+	" nm_Walk(40.5, FwdKey) "
+	" nm_Walk(34.5, RightKey) "
+	" nm_Walk(27, FwdKey) "
+
+	switch % " HiveSlot "
+		{
+		case 3:
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+		default:
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
+		}
+	}
+else { ;use yellow cannon
+    send {space down}
+    Hypersleep(50)
+    send {space up}
+    " nm_walk(4, rightkey) "
+    Hypersleep(1100)
+    send {e down}
+    HyperSleep(100)
+    send {e up}
+    Hypersleep(3000)
+    " nm_Walk(34, FwdKey) "
+
+	switch % " HiveSlot "
+		{
+		case 3:
+		" nm_Walk(2.7, BackKey) " ;center on hive pad 3
+
+		default:
+		" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+		" nm_Walk(35, RightKey) " ;walk to ramp
+		" nm_Walk(2.7, BackKey) " ;center with hive pads
+		}
+    }
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update
+; [2024-01-15/rpertusio] Now uses yellow cannon if 12+ bees
+; [2024-01-15/rpertusio] Aligns with default SpawnLocation, saves walking if player chose Hive 3

--- a/paths/wf-sunflower.ahk
+++ b/paths/wf-sunflower.ahk
@@ -1,12 +1,13 @@
 ﻿paths["sunflower"] := "
 (LTrim Join`r`n
 send {" RotLeft " 2}
-" nm_Walk(13.5, RightKey) "
-" nm_Walk(45, FwdKey) "
-" nm_Walk(2.25, BackKey) "
-" nm_Walk(40, FwdKey, LeftKey) " ; 49.5
-" nm_Walk(5, FwdKey) "
-" nm_Walk(3, BackKey) " ; 2.25
-" nm_Walk(27, RightKey) "
-" nm_Walk(3.5, FwdKey) "
+" nm_Walk(13.5, RightKey) " ;walk to edge of field
+" nm_Walk(45, FwdKey) "     ;walk to corner (special sprout)
+" nm_Walk(2.25, BackKey) "  ;back out of corner
+" nm_Walk(25, FwdKey, LeftKey) " ;move diagonally towards hives
+" nm_Walk(13.5, FwdKey) "   ;walk towards hives
+" nm_Walk(1.5, BackKey) " ;walk backwards to avoid thicker hives
+" nm_Walk(10, RightKey) " ;walk to ramp
+" nm_Walk(2.7, BackKey) " ;center with hive pads
 )"
+; [2024-01-15/rpertusio] Avoid using corner (Hive 1 and ramp) where character gets stuck after 2024-01-12 BSS update

--- a/submacros/natro_macro.ahk
+++ b/submacros/natro_macro.ahk
@@ -9454,16 +9454,6 @@ nm_findHiveSlot(){
 		Gdip_DisposeImage(pBMScreen)
 
 		; find hive slot
-		movement := "
-		(LTrim Join`r`n
-		" nm_Walk(4, FwdKey) "
-		" nm_Walk(4.25, BackKey) " ; 5.25
-		)"
-		nm_createWalk(movement)
-		KeyWait, F14, D T5 L
-		KeyWait, F14, T20 L
-		nm_endWalk()
-
 		DllCall("GetSystemTimeAsFileTime","int64p",s)
 		n := s, f := s+150000000
 		SendInput {%LeftKey% down}


### PR DESCRIPTION
- ADDED Stump Field return to hive to walk (instead of Yellow Cannon) if < 12 bees
- UPDATED paths to avoid getting stuck between Hive 1 and ramp (after 2024-01-12 BSS update, Issue #174 )
- UPDATED most paths to align walk path with SpawnPoint in front of Hive 3
- UPDATED Pepper Field camera to follow player when returning to hive

Tested:
- All fields with Gather Mins set at 0  (to immediately travel TO and FROM fields)
- Number of Bees set to 11 (below Yellow Cannon ability, and no glider from Pine Tree field)
- Number of Bees set to 50 (Yellow Cannon and Glider from Pine Tree field)
- Hive slots 1, 2, and 3 claimed to ensure thickness of new hives does not interfere)
- MoveSpeed Correct On (however, extensive testing was not performed with Haste or other MoveSpeed modifiers). These changes assume that MoveSpeed Correction negates the need to align to the Hive 1 & Ramp corner, and (for Strawberry field) negates the need to align to the Instant Converter machine.

