### PR TITLE
FIX: Typos in the monster respawn info message box

### DIFF
--- a/submacros/natro_macro.ahk
+++ b/submacros/natro_macro.ahk
@@ -4983,7 +4983,7 @@ nm_BossConfigHelp(*){ ; monster respawn time information
 
 	Boss health/time settings:
 	Enter the boss's health in the text box.
-	The health needs to be written in wihtout commas seperating the health and it will automatically be converted into a percentage.
+	The health needs to be written in without commas separating the health and it will automatically be converted into a percentage.
 	As for the time, the time options are in 5,10,15 minutes with another option being the kill option.
 	The Kill option will basically attack the boss until the boss dies or if you die.
 	The only bosses with this feature are Stump Snail and Commando Chick.


### PR DESCRIPTION
Fix minor typos in the monster respawn information.

To reproduce the problem/verify the fix:
1. Click on the "Collect/Kill" tab
2. Choose "Kill"
3. Then click on the "?" button next to the Bosses section
![image](https://github.com/NatroTeam/NatroMacro/assets/7022645/a1e7a49c-9b0e-4b6b-9b84-a1bc686a7400)

Screenshot of the fix:
![image](https://github.com/NatroTeam/NatroMacro/assets/7022645/fac57043-1852-4efa-9e81-49afe7e63a96)
