### PR TITLE
Make nm_ForceLabel to force start to prevent issues

### DIFF
--- a/submacros/natro_macro.ahk
+++ b/submacros/natro_macro.ahk
@@ -20582,6 +20582,7 @@ Background(){
 	nm_setStats()
 }
 
+ForceLabelStart := false
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; HOTKEYS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -20625,7 +20626,7 @@ start(*){
 				return
 		}
 	}
-	if !ForceStart {
+	if !ForceStart && !ForceLabelStart {
 		;Field drift compensation warning
 		Loop 3 {
 			;if gathering in a field with FDC on and without supreme set in settings, warn user
@@ -21000,8 +21001,10 @@ nm_ForceLabel(wParam, *){
 	{
 		case 1:
 		if (MainGui["StartButton"].Enabled = 1)
+		{
+			global ForceLabelStart := true
 			SetTimer start, -500
-
+		}
 		case 2:
 		nm_pause()
 


### PR DESCRIPTION
<!--❗❗❗
Make sure to include:
- type of pull request (bug fix, optimisation, new feature, etc.)
- summary of changes you have made (if applicable, link to an issue which was fixed)
- any additional information we should know
❗❗❗-->
# Make nm_ForceLabel to force start to stuck at message box
When user start the game through their discord bot or by sending a `0x5550` message with `wParam=1` to Natro Macro, `nm_ForceLabel` is being called, but sometimes upon starting there will be a message box which prevents Natro Macro from starting, which can be disabled by setting `ForceStart` to true. Users without setting that will have Natro Macro stuck at that message box when starting if a message box showed up.


# Implementation
This PR makes it so it also checks for `ForceLabelStart` on starting so it wil know to force start or not