### PR TITLE
Fix: correct pointer size mismatch in GDI+ wrapper resulting in access violation

### DIFF
--- a/lib/Gdip_All.ahk
+++ b/lib/Gdip_All.ahk
@@ -2864,7 +2864,7 @@ Gdip_ResetClip(pGraphics)
 Gdip_GetClipRegion(pGraphics)
 {
 	Region := Gdip_CreateRegion()
-	DllCall("gdiplus\GdipGetClip", "UPtr", pGraphics, "UInt", Region)
+	DllCall("gdiplus\GdipGetClip", "UPtr", pGraphics, "UPtr", Region)
 	return Region
 }
 
@@ -2875,7 +2875,7 @@ Gdip_SetClipRegion(pGraphics, Region, CombineMode:=0)
 
 Gdip_CreateRegion()
 {
-	DllCall("gdiplus\GdipCreateRegion", "UInt*", &Region:=0)
+	DllCall("gdiplus\GdipCreateRegion", "UPtr*", &Region:=0)
 	return Region
 }
 


### PR DESCRIPTION
- Fix to #1254 

Region pointer is mismatched as `UInt` which is **32-bit**. However, pointers are in **64-bit** when the program is running in **x64** causing pointers assigned to Region to be truncated resulting in bogus pointers, and subsequent Access Violation errors.

This is a quick fix to said issue by changing `UInt` into the proper `UPtr` type, which is either **32-bit** or **64-bit** depending on program.


